### PR TITLE
예매 내역 화면 연동 API 수정

### DIFF
--- a/src/main/java/com/kb/wallet/seat/domain/Seat.java
+++ b/src/main/java/com/kb/wallet/seat/domain/Seat.java
@@ -24,6 +24,9 @@ public class Seat {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(nullable = false)
+  private int seatNo;
+
   @ManyToOne
   @JoinColumn(name = "section_id")
   private Section section;

--- a/src/main/java/com/kb/wallet/ticket/controller/TicketController.java
+++ b/src/main/java/com/kb/wallet/ticket/controller/TicketController.java
@@ -6,11 +6,13 @@ import com.kb.wallet.member.domain.Member;
 import com.kb.wallet.member.service.MemberService;
 import com.kb.wallet.qrcode.dto.request.DecryptionRequest;
 import com.kb.wallet.qrcode.dto.response.DecryptionResponse;
+import com.kb.wallet.ticket.constant.TicketStatus;
 import com.kb.wallet.ticket.domain.Ticket;
 import com.kb.wallet.ticket.dto.request.TicketExchangeRequest;
 import com.kb.wallet.ticket.dto.request.TicketRequest;
 import com.kb.wallet.ticket.dto.response.QrCreationResponse;
 import com.kb.wallet.ticket.dto.response.TicketExchangeResponse;
+import com.kb.wallet.ticket.dto.response.TicketListResponse;
 import com.kb.wallet.ticket.dto.response.TicketResponse;
 import com.kb.wallet.ticket.service.TicketService;
 import java.util.List;
@@ -20,15 +22,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/tickets")
@@ -50,11 +44,14 @@ public class TicketController {
   }
 
   @GetMapping
-  public ApiResponse<Page<TicketResponse>> getUserTickets(
+  public ApiResponse<Page<TicketListResponse>> getUserTickets(
       @AuthenticationPrincipal Member member,
       @RequestParam(name = "page", defaultValue = "0") int page,
-      @RequestParam(name = "size", defaultValue = "10") int size) {
-    Page<TicketResponse> tickets = ticketService.findAllBookedTickets(member.getEmail(), page,
+      @RequestParam(name = "size", defaultValue = "10") int size,
+      @RequestParam(name = "status", required = false) String status) {
+    TicketStatus ticketStatus = "booked".equalsIgnoreCase(status) ? TicketStatus.BOOKED : null;
+    Page<TicketListResponse> tickets = ticketService.findAllBookedTickets(member.getEmail(),
+        ticketStatus, page,
         size);
     return ApiResponse.ok(tickets);
   }

--- a/src/main/java/com/kb/wallet/ticket/dto/response/TicketListResponse.java
+++ b/src/main/java/com/kb/wallet/ticket/dto/response/TicketListResponse.java
@@ -1,0 +1,73 @@
+package com.kb.wallet.ticket.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.kb.wallet.seat.constant.Grade;
+import com.kb.wallet.ticket.constant.TicketStatus;
+import com.kb.wallet.ticket.domain.Ticket;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TicketListResponse {
+
+  private Long id;
+  private String title;
+  private TicketStatus ticketStatus;
+  private String createdAt;
+  private String validUntil;
+  private String cancelUntil;
+  private String place;
+  private String scheduleDate;
+  private String startTime;
+  private String posterImageUrl;
+  private Grade grade;
+  private int seatNo;
+
+  public TicketListResponse(Long id, String title, TicketStatus ticketStatus, LocalDateTime createdAt,
+      LocalDateTime validUntil, LocalDateTime cancelUntil, String place,
+      LocalDate scheduleDate, LocalTime startTime, String posterImageUrl,
+      Grade grade, int seatNo) {
+    this.id = id;
+    this.title = title;
+    this.ticketStatus = ticketStatus;
+    this.createdAt = formatDateTime(createdAt);
+    this.validUntil = formatDateTime(validUntil);
+    this.cancelUntil = formatDateTime(cancelUntil);
+    this.place = place;
+    this.scheduleDate = formatDate(scheduleDate);
+    this.startTime = formatTime(startTime);
+    this.posterImageUrl = posterImageUrl;
+    this.grade = grade;
+    this.seatNo = seatNo;
+  }
+
+  // LocalDateTime을 "년.월.일(요일) 시:분" 형태로 변환하는 메서드
+  private String formatDateTime(LocalDateTime dateTime) {
+    if (dateTime == null) return null;
+    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd(E) HH:mm", Locale.KOREAN);
+    return dateTime.format(dateTimeFormatter);
+  }
+
+  // LocalDate를 "년.월.일(요일)" 형태로 변환하는 메서드
+  private String formatDate(LocalDate date) {
+    if (date == null) return null;
+    DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd(E)", Locale.KOREAN);
+    return date.format(dateFormatter);
+  }
+
+  // LocalTime을 "시:분" 형태로 변환하는 메서드
+  private String formatTime(LocalTime time) {
+    if (time == null) return null;
+    DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+    return time.format(timeFormatter);
+  }
+}

--- a/src/main/java/com/kb/wallet/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/kb/wallet/ticket/repository/TicketRepository.java
@@ -3,6 +3,7 @@ package com.kb.wallet.ticket.repository;
 import com.kb.wallet.member.domain.Member;
 import com.kb.wallet.ticket.constant.TicketStatus;
 import com.kb.wallet.ticket.domain.Ticket;
+import com.kb.wallet.ticket.dto.response.TicketListResponse;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,8 +24,19 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
       @Param("id") Long id,
       @Param("email") String email);
 
-  @Query("SELECT t FROM Ticket t WHERE t.member.email = :email AND t.ticketStatus = :status")
-  Page<Ticket> findTicketsByMemberAndTicketStatus(
+  @Query("SELECT new com.kb.wallet.ticket.dto.response.TicketListResponse(" +
+      "t.id, m.title, t.ticketStatus, " +
+      "t.createdAt, t.validUntil, t.cancelUntil, " +
+      "m.place, sc.date, sc.startTime, " +
+      "m.posterImageUrl, sec.grade, s.seatNo) " +
+      "FROM Ticket t " +
+      "JOIN t.musical m " +
+      "JOIN t.seat s " +
+      "JOIN s.section sec " +
+      "JOIN s.schedule sc " +
+      "WHERE t.member.email = :email " +
+      "AND (:status IS NULL OR t.ticketStatus = :status)")
+  Page<TicketListResponse> findTicketsByMemberAndTicketStatus(
       @Param("email") String email,
       @Param("status") TicketStatus status,
       Pageable pageable);

--- a/src/main/java/com/kb/wallet/ticket/service/TicketService.java
+++ b/src/main/java/com/kb/wallet/ticket/service/TicketService.java
@@ -3,11 +3,13 @@ package com.kb.wallet.ticket.service;
 import com.kb.wallet.member.domain.Member;
 import com.kb.wallet.qrcode.dto.request.DecryptionRequest;
 import com.kb.wallet.qrcode.dto.response.DecryptionResponse;
+import com.kb.wallet.ticket.constant.TicketStatus;
 import com.kb.wallet.ticket.domain.Ticket;
 import com.kb.wallet.ticket.dto.request.TicketExchangeRequest;
 import com.kb.wallet.ticket.dto.request.TicketRequest;
 import com.kb.wallet.ticket.dto.response.QrCreationResponse;
 import com.kb.wallet.ticket.dto.response.TicketExchangeResponse;
+import com.kb.wallet.ticket.dto.response.TicketListResponse;
 import com.kb.wallet.ticket.dto.response.TicketResponse;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -18,7 +20,8 @@ public interface TicketService {
 
   Ticket findTicketById(Long id);
 
-  Page<TicketResponse> findAllBookedTickets(String email, int page, int size);
+  Page<TicketListResponse> findAllBookedTickets(String email, TicketStatus ticketStatus, int page,
+      int size);
 
   List<TicketResponse> saveTicket(String email, TicketRequest ticketRequest);
 

--- a/src/main/java/com/kb/wallet/ticket/service/TicketServiceImpl.java
+++ b/src/main/java/com/kb/wallet/ticket/service/TicketServiceImpl.java
@@ -22,6 +22,7 @@ import com.kb.wallet.ticket.dto.request.TicketExchangeRequest;
 import com.kb.wallet.ticket.dto.request.TicketRequest;
 import com.kb.wallet.ticket.dto.response.QrCreationResponse;
 import com.kb.wallet.ticket.dto.response.TicketExchangeResponse;
+import com.kb.wallet.ticket.dto.response.TicketListResponse;
 import com.kb.wallet.ticket.dto.response.TicketResponse;
 import com.kb.wallet.ticket.repository.TicketExchangeRepository;
 import com.kb.wallet.ticket.repository.TicketMapper;
@@ -105,11 +106,10 @@ public class TicketServiceImpl implements TicketService {
   }
 
   @Override
-  public Page<TicketResponse> findAllBookedTickets(String email, int page, int size) {
+  public Page<TicketListResponse> findAllBookedTickets(String email, TicketStatus ticketStatus,
+      int page, int size) {
     Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-    Page<Ticket> ticketsByMemberIdAndTicketStatus =
-        ticketRepository.findTicketsByMemberAndTicketStatus(email, TicketStatus.BOOKED, pageable);
-    return ticketsByMemberIdAndTicketStatus.map(TicketResponse::toTicketResponse);
+    return ticketRepository.findTicketsByMemberAndTicketStatus(email, ticketStatus, pageable);
   }
 
   public void updateStatusChecked(Ticket ticket) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* 기능 추가 상세 설명 필요시 작성하기
  
  - [x] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/ticket-list/chs -> dev

### 변경 사항
- @RequestParam String status 추가하여 상태 필터링 기능 구현
- Seat 엔티티에 seatNo 속성 추가
- 티켓 목록 조회 API의 반환 타입을 ApiResponse<Page<TicketResponse>>에서 ApiResponse<Page<TicketListResponse>>로 변경
- TicketRepository의 findTicketsByMemberAndTicketStatus() 메서드 쿼리 수정

### 검증 여부
- [ ] postman으로 api 테스트 완료했습니다.
