### PR TITLE
TicketService의 ticketing 로직 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,13 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Build with Gradle
-        run: ./gradlew clean build
+      - name: Build with Gradle (dev 환경)
+        run: ./gradlew clean build -Dspring.profiles.active=dev
+        if: github.ref == 'refs/heads/dev-branch' # dev 브랜치에 대한 설정
+
+      - name: Build with Gradle (prod 환경)
+        run: ./gradlew clean build -Dspring.profiles.active=prod
+        if: github.ref == 'refs/heads/prod-branch' # prod 브랜치에 대한 설정
 
       - name: WAR 파일 이름을 metal-wallet-server.war로 변경
         run: mv build/libs/*.war build/libs/metal-wallet-server.war
@@ -47,6 +52,9 @@ jobs:
             mkdir /home/ubuntu/metal-wallet-server/current
             mv /home/ubuntu/metal-wallet-server/tobe/metal-wallet-server.war /home/ubuntu/metal-wallet-server/current/metal-wallet-server.war
             echo "${{ secrets.APPLICATION_PROPERTIES }}" > /home/ubuntu/metal-wallet-server/current/application.properties
-            cd /home/ubuntu/metal-wallet-server/current
+            echo "jwt.secret=${{ secrets.JWT_SECRET }}" >> /home/ubuntu/metal-wallet-server/current/application.properties
+            echo "jwt.token.validity=86400000" >> /home/ubuntu/metal-wallet-server/current/application.properties
+
+            cd /home/ubuntu/metal-wallet-server/current  
             sudo fuser -k -n tcp 8080 || true
             sudo systemctl restart tomcat

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ dependencies {
 
     // Provides annotations such as @PostConstruct
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+    // Apache Commons DBCP2 (for BasicDataSource)
+    implementation 'org.apache.commons:commons-dbcp2:2.9.0'
 }
 
 test {

--- a/src/main/java/com/kb/wallet/global/config/AppConfig.java
+++ b/src/main/java/com/kb/wallet/global/config/AppConfig.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -29,6 +30,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
+@Import(DataSourceConfig.class)
 @ComponentScan(basePackages = {
     "com.kb.wallet"
 })

--- a/src/main/java/com/kb/wallet/global/config/DataSourceConfig.java
+++ b/src/main/java/com/kb/wallet/global/config/DataSourceConfig.java
@@ -1,0 +1,60 @@
+package com.kb.wallet.global.config;
+
+import javax.sql.DataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+public class DataSourceConfig {
+  @Configuration
+  @Profile("dev")
+  @PropertySource("classpath:application-dev.properties")
+  static class DevConfig {
+
+    @Value("${spring.datasource.url}")
+    private String datasourceUrl;
+
+    @Value("${spring.datasource.username}")
+    private String datasourceUsername;
+
+    @Value("${spring.datasource.password}")
+    private String datasourcePassword;
+
+    @Bean
+    public DataSource dataSource() {
+      BasicDataSource dataSource = new BasicDataSource();
+      dataSource.setUrl(datasourceUrl);
+      dataSource.setUsername(datasourceUsername);
+      dataSource.setPassword(datasourcePassword);
+      return dataSource;
+    }
+  }
+
+  @Configuration
+  @Profile("prod")
+  @PropertySource("classpath:application-prod.properties")
+  static class ProdConfig {
+
+    @Value("${spring.datasource.url}")
+    private String datasourceUrl;
+
+    @Value("${spring.datasource.username}")
+    private String datasourceUsername;
+
+    @Value("${spring.datasource.password}")
+    private String datasourcePassword;
+
+    @Bean
+    public DataSource dataSource() {
+      BasicDataSource dataSource = new BasicDataSource();
+      dataSource.setUrl(datasourceUrl);
+      dataSource.setUsername(datasourceUsername);
+      dataSource.setPassword(datasourcePassword);
+      return dataSource;
+    }
+  }
+}

--- a/src/main/java/com/kb/wallet/global/config/ProfileInitializer.java
+++ b/src/main/java/com/kb/wallet/global/config/ProfileInitializer.java
@@ -1,0 +1,32 @@
+package com.kb.wallet.global.config;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+public class ProfileInitializer implements ServletContextListener {
+  @Override
+  public void contextInitialized(ServletContextEvent event) {
+    WebApplicationContext ctx = WebApplicationContextUtils
+        .getWebApplicationContext(event.getServletContext());
+
+    if (ctx != null) {
+      ConfigurableEnvironment env = (ConfigurableEnvironment) ctx.getEnvironment();
+
+      String activeProfile = System.getenv("SPRING_PROFILES_ACTIVE");
+      if (activeProfile != null && !activeProfile.isEmpty()) {
+        env.setActiveProfiles(activeProfile);
+      } else {
+        env.setActiveProfiles("dev");
+      }
+    } else {
+//      System.out.println("Spring Context 초기화 실패");
+    }
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent sce) {
+  }
+}

--- a/src/main/java/com/kb/wallet/global/config/SecurityConfig.java
+++ b/src/main/java/com/kb/wallet/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ package com.kb.wallet.global.config;
 import com.kb.wallet.jwt.JwtFilter;
 import com.kb.wallet.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,8 @@ import org.springframework.web.filter.CorsFilter;
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @ComponentScan(basePackages = {"com.kb.wallet.member", "com.kb.wallet.jwt"})
 public class SecurityConfig {
-
+  @Value("${frontend.url}")
+  private String frontendUrl;
   private final TokenProvider tokenProvider;
   private final UserDetailsService userDetailsService;
 
@@ -54,8 +56,7 @@ public class SecurityConfig {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
-    config.addAllowedOrigin("http://localhost:5173"); // 허용할 도메인 설정
-    config.addAllowedOrigin("https://kbfinance-team-metalwallet.github.io"); // 허용할 도메인 설정
+    config.addAllowedOrigin(frontendUrl);
     config.addAllowedHeader("*");
     config.addAllowedMethod("*");
     source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/kb/wallet/global/config/WebAppInitializer.java
+++ b/src/main/java/com/kb/wallet/global/config/WebAppInitializer.java
@@ -2,6 +2,8 @@ package com.kb.wallet.global.config;
 
 
 import javax.servlet.Filter;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
@@ -9,7 +11,6 @@ import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatche
 public class WebAppInitializer extends AbstractAnnotationConfigDispatcherServletInitializer {
 
   public WebAppInitializer() {
-    System.out.println("WebAppInitializer created");
   }
 
   //인코딩 필터 설정
@@ -33,6 +34,13 @@ public class WebAppInitializer extends AbstractAnnotationConfigDispatcherServlet
   @Override
   protected String[] getServletMappings() {
     return new String[]{"/"};
+  }
+
+  @Override
+  public void onStartup(ServletContext servletContext) throws ServletException {
+    super.onStartup(servletContext);
+
+    servletContext.addListener(new ProfileInitializer());
   }
 }
 

--- a/src/main/java/com/kb/wallet/global/config/WebConfig.java
+++ b/src/main/java/com/kb/wallet/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.kb.wallet.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -12,6 +13,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableWebMvc
 @ComponentScan(basePackages = "com.kb.wallet")
 public class WebConfig implements WebMvcConfigurer {
+  @Value("${frontend.url}")
+  private String frontendUrl;
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
@@ -30,7 +33,7 @@ public class WebConfig implements WebMvcConfigurer {
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
         .allowedMethods("*")
-        .allowedOrigins("https://kbfinance-team-metalwallet.github.io", "http://localhost:5173")
+        .allowedOrigins(frontendUrl)
         .allowedOriginPatterns("*")
         .allowedHeaders("*")
         .allowCredentials(true);

--- a/src/main/java/com/kb/wallet/seat/domain/Seat.java
+++ b/src/main/java/com/kb/wallet/seat/domain/Seat.java
@@ -1,5 +1,7 @@
 package com.kb.wallet.seat.domain;
 
+import com.kb.wallet.global.common.status.ErrorCode;
+import com.kb.wallet.global.exception.CustomException;
 import com.kb.wallet.ticket.domain.Schedule;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -37,6 +39,17 @@ public class Seat {
 
   @Column
   private boolean isAvailable;
+
+  public void checkSeatAvailability() {
+    if (!this.isAvailable()) {
+      throw new CustomException(ErrorCode.SEAT_ALREADY_BOOKED_ERROR);
+    }
+  }
+
+  public void updateSeatAvailability() {
+    markAsUnavailable();
+    this.section.decrementAvailableSeats();
+  }
 
   public void markAsUnavailable() {
     this.isAvailable = false;

--- a/src/main/java/com/kb/wallet/seat/service/SeatService.java
+++ b/src/main/java/com/kb/wallet/seat/service/SeatService.java
@@ -5,6 +5,4 @@ import com.kb.wallet.seat.domain.Seat;
 public interface SeatService {
 
   Seat getSeatById(Long seatId);
-
-  void checkSeatAvailability(Seat seat);
 }

--- a/src/main/java/com/kb/wallet/seat/service/SeatServiceImpl.java
+++ b/src/main/java/com/kb/wallet/seat/service/SeatServiceImpl.java
@@ -20,11 +20,4 @@ public class SeatServiceImpl implements SeatService {
     return seatRepository.findById(seatId)
         .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND_ERROR));
   }
-
-  @Override
-  public void checkSeatAvailability(Seat seat) {
-    if (!seat.isAvailable()) {
-      throw new CustomException(ErrorCode.SEAT_ALREADY_BOOKED_ERROR);
-    }
-  }
 }

--- a/src/main/java/com/kb/wallet/ticket/controller/TicketController.java
+++ b/src/main/java/com/kb/wallet/ticket/controller/TicketController.java
@@ -14,6 +14,7 @@ import com.kb.wallet.ticket.dto.response.TicketListResponse;
 import com.kb.wallet.ticket.dto.response.TicketResponse;
 import com.kb.wallet.ticket.service.TicketService;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -38,8 +39,8 @@ public class TicketController {
   @PostMapping
   public ApiResponse<List<TicketResponse>> createTicket(
       @AuthenticationPrincipal Member member,
-      @RequestBody TicketRequest ticketRequest) {
-    List<TicketResponse> tickets = ticketService.saveTicket(member.getEmail(), ticketRequest);
+      @RequestBody @Valid TicketRequest ticketRequest) {
+    List<TicketResponse> tickets = ticketService.ticketing(member.getEmail(), ticketRequest);
     return ApiResponse.created(tickets);
   }
 

--- a/src/main/java/com/kb/wallet/ticket/domain/Ticket.java
+++ b/src/main/java/com/kb/wallet/ticket/domain/Ticket.java
@@ -70,7 +70,7 @@ public class Ticket {
   @Column
   private String deviceId;
 
-  public static Ticket createBookedTicket(Member member, Musical musical, Seat seat) {
+  public static Ticket createBookedTicket(Member member, Musical musical, Seat seat, String deviceId) {
 
     LocalDateTime musicalStartDateTime = LocalDateTime.of(seat.getSchedule().getDate(),
         seat.getSchedule().getStartTime());
@@ -83,7 +83,7 @@ public class Ticket {
         .seat(seat)
         .validUntil(musicalStartDateTime)
         .cancelUntil(cancelUntilDateTime)
-        .deviceId(builder().deviceId)
+        .deviceId(deviceId)
         .build();
   }
 

--- a/src/main/java/com/kb/wallet/ticket/dto/request/TicketRequest.java
+++ b/src/main/java/com/kb/wallet/ticket/dto/request/TicketRequest.java
@@ -1,6 +1,9 @@
 package com.kb.wallet.ticket.dto.request;
 
+import com.kb.wallet.global.common.status.ErrorCode;
+import com.kb.wallet.global.exception.CustomException;
 import java.util.List;
+import javax.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +15,9 @@ import lombok.Setter;
 @Setter
 public class TicketRequest {
 
+  @NotEmpty(message = "좌석 ID는 필수입니다.")
   private List<Long> seatId;
+
+  @NotEmpty(message = "디바이스 ID는 필수입니다.")
   private String deviceId;
 }

--- a/src/main/java/com/kb/wallet/ticket/service/TicketService.java
+++ b/src/main/java/com/kb/wallet/ticket/service/TicketService.java
@@ -39,7 +39,7 @@ public interface TicketService {
   List<TicketListResponse> findAllBookedTickets(String email, TicketStatus ticketStatus, int page,
       int size, Long cursor);
 
-  List<TicketResponse> saveTicket(String email, TicketRequest ticketRequest);
+  List<TicketResponse> ticketing(String email, TicketRequest ticketRequest);
 
   void cancelTicket(String email, Long ticketId);
 

--- a/src/main/java/com/kb/wallet/ticket/service/TicketServiceImpl.java
+++ b/src/main/java/com/kb/wallet/ticket/service/TicketServiceImpl.java
@@ -56,31 +56,32 @@ public class TicketServiceImpl implements TicketService {
 
   @Override
   @Transactional(transactionManager = "jpaTransactionManager")
-  public List<TicketResponse> saveTicket(String email, TicketRequest ticketRequest) {
-    if (ticketRequest.getSeatId() == null || ticketRequest.getSeatId().isEmpty()) {
-      throw new CustomException(ErrorCode.NOT_VALID_ERROR, "좌석 ID는 필수입니다.");
-    }
-    if (ticketRequest.getDeviceId() == null || ticketRequest.getDeviceId().isEmpty()) {
-      throw new CustomException(ErrorCode.NOT_VALID_ERROR, "디바이스 ID는 필수입니다.");
-    }
+  public List<TicketResponse> ticketing(String email, TicketRequest ticketRequest) {
     Member member = memberService.getMemberByEmail(email);
     List<TicketResponse> responses = new ArrayList<>();
+
     for (Long seatId : ticketRequest.getSeatId()) {
-      Seat seat = seatService.getSeatById(seatId);
-      seatService.checkSeatAvailability(seat);
-
-      Ticket bookedTicket = Ticket.createBookedTicket(member, seat.getSchedule().getMusical(),
-          seat);
-      bookedTicket.setDeviceId(ticketRequest.getDeviceId());
-
-      Ticket savedTicket = ticketRepository.save(bookedTicket);
-      responses.add(TicketResponse.toTicketResponse(savedTicket));
-
-      seat.markAsUnavailable();
-      seat.getSection().decrementAvailableSeats();
+      Ticket bookedTicket = bookTicketForSeat(seatId, ticketRequest.getDeviceId(), member);
+      responses.add(TicketResponse.toTicketResponse(bookedTicket));
     }
     return responses;
   }
+
+  private Ticket bookTicketForSeat(Long seatId, String deviceId, Member member) {
+    Seat seat = seatService.getSeatById(seatId);
+    seat.checkSeatAvailability();
+
+    Ticket ticket = saveTicket(member, seat, deviceId);
+    seat.updateSeatAvailability();
+
+    return ticket;
+  }
+
+  private Ticket saveTicket(Member member, Seat seat, String deviceId) {
+    Ticket ticket = Ticket.createBookedTicket(member,seat.getSchedule().getMusical(), seat, deviceId);
+    return ticketRepository.save(ticket);
+  }
+
 
   @Override
   public ProposedEncryptResponse provideEncryptElement(Long ticketId, String email,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* 기능 추가 상세 설명 필요시 작성하기
  
  - [x] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/ticketing/chs -> dev

### 변경 사항
- TicketService의 saveTicket 메서드를 ticketing으로 명명 변경
- Seat Entity에 checkSeatAvailability() 메서드를 추가하여 
  좌석의 예약 가능성을 확인하도록 로직을 이동
- SeatService의 checkSeatAvailability 메서드를 제거하고, 
  Seat Entity로 메서드를 이동
- Ticket Entity의 builder 패턴 수정 및 deviceId parameter 추가
- TicketRequest에 대한 유효성 체크 로직을 TicketRequest 클래스 내부로 이동시켜 TicketController에 @Valid을 추가
- TicketService의 티켓팅 로직을 bookTicketForSeat()와 
  updateSeatAvailability() 메서드로 분리

### 검증 여부
- [ ] postman으로 api 테스트 완료했습니다.
  - 여러 담당자의 동시 진행으로 인해 테스트를 진행하지 못함
