### PR TITLE
TicketService의 ticketing 로직 수정

### DIFF
--- a/src/main/java/com/kb/wallet/seat/domain/Seat.java
+++ b/src/main/java/com/kb/wallet/seat/domain/Seat.java
@@ -1,5 +1,7 @@
 package com.kb.wallet.seat.domain;
 
+import com.kb.wallet.global.common.status.ErrorCode;
+import com.kb.wallet.global.exception.CustomException;
 import com.kb.wallet.ticket.domain.Schedule;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -37,9 +39,15 @@ public class Seat {
 
   @Column
   private boolean isAvailable;
+  public void checkSeatAvailability() {
+    if (!this.isAvailable()) {
+      throw new CustomException(ErrorCode.SEAT_ALREADY_BOOKED_ERROR);
+    }
+  }
 
-  public void markAsUnavailable() {
+  public void updateSeatAvailability() {
     this.isAvailable = false;
+    this.section.decrementAvailableSeats();
   }
 
   public void markAsAvailable() {

--- a/src/main/java/com/kb/wallet/seat/service/SeatService.java
+++ b/src/main/java/com/kb/wallet/seat/service/SeatService.java
@@ -5,6 +5,4 @@ import com.kb.wallet.seat.domain.Seat;
 public interface SeatService {
 
   Seat getSeatById(Long seatId);
-
-  void checkSeatAvailability(Seat seat);
 }

--- a/src/main/java/com/kb/wallet/seat/service/SeatServiceImpl.java
+++ b/src/main/java/com/kb/wallet/seat/service/SeatServiceImpl.java
@@ -20,11 +20,4 @@ public class SeatServiceImpl implements SeatService {
     return seatRepository.findById(seatId)
         .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND_ERROR));
   }
-
-  @Override
-  public void checkSeatAvailability(Seat seat) {
-    if (!seat.isAvailable()) {
-      throw new CustomException(ErrorCode.SEAT_ALREADY_BOOKED_ERROR);
-    }
-  }
 }

--- a/src/main/java/com/kb/wallet/ticket/controller/TicketController.java
+++ b/src/main/java/com/kb/wallet/ticket/controller/TicketController.java
@@ -14,6 +14,7 @@ import com.kb.wallet.ticket.dto.response.TicketListResponse;
 import com.kb.wallet.ticket.dto.response.TicketResponse;
 import com.kb.wallet.ticket.service.TicketService;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -38,8 +39,8 @@ public class TicketController {
   @PostMapping
   public ApiResponse<List<TicketResponse>> createTicket(
       @AuthenticationPrincipal Member member,
-      @RequestBody TicketRequest ticketRequest) {
-    List<TicketResponse> tickets = ticketService.saveTicket(member.getEmail(), ticketRequest);
+      @RequestBody @Valid TicketRequest ticketRequest) {
+    List<TicketResponse> tickets = ticketService.ticketing(member.getEmail(), ticketRequest);
     return ApiResponse.created(tickets);
   }
 

--- a/src/main/java/com/kb/wallet/ticket/domain/Ticket.java
+++ b/src/main/java/com/kb/wallet/ticket/domain/Ticket.java
@@ -70,7 +70,7 @@ public class Ticket {
   @Column
   private String deviceId;
 
-  public static Ticket createBookedTicket(Member member, Musical musical, Seat seat) {
+  public static Ticket createBookedTicket(Member member, Musical musical, Seat seat, String deviceId) {
 
     LocalDateTime musicalStartDateTime = LocalDateTime.of(seat.getSchedule().getDate(),
         seat.getSchedule().getStartTime());
@@ -83,7 +83,7 @@ public class Ticket {
         .seat(seat)
         .validUntil(musicalStartDateTime)
         .cancelUntil(cancelUntilDateTime)
-        .deviceId(builder().deviceId)
+        .deviceId(deviceId)
         .build();
   }
 

--- a/src/main/java/com/kb/wallet/ticket/dto/request/TicketRequest.java
+++ b/src/main/java/com/kb/wallet/ticket/dto/request/TicketRequest.java
@@ -1,7 +1,7 @@
 package com.kb.wallet.ticket.dto.request;
 
 import java.util.List;
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +12,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TicketRequest {
-  @NotBlank(message = "좌석 ID는 필수입니다.")
+  @NotEmpty(message = "좌석 ID는 필수입니다.")
+  @Size(min = 1, message = "최소 1개의 좌석 ID가 필요합니다.")
   private List<Long> seatId;
 
   @NotBlank(message = "디바이스 ID는 필수입니다.")

--- a/src/main/java/com/kb/wallet/ticket/dto/request/TicketRequest.java
+++ b/src/main/java/com/kb/wallet/ticket/dto/request/TicketRequest.java
@@ -1,6 +1,7 @@
 package com.kb.wallet.ticket.dto.request;
 
 import java.util.List;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TicketRequest {
-
+  @NotBlank(message = "좌석 ID는 필수입니다.")
   private List<Long> seatId;
+
+  @NotBlank(message = "디바이스 ID는 필수입니다.")
   private String deviceId;
 }

--- a/src/main/java/com/kb/wallet/ticket/service/TicketService.java
+++ b/src/main/java/com/kb/wallet/ticket/service/TicketService.java
@@ -39,7 +39,7 @@ public interface TicketService {
   List<TicketListResponse> findAllBookedTickets(String email, TicketStatus ticketStatus, int page,
       int size, Long cursor);
 
-  List<TicketResponse> saveTicket(String email, TicketRequest ticketRequest);
+  List<TicketResponse> ticketing(String email, TicketRequest ticketRequest);
 
   void cancelTicket(String email, Long ticketId);
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* 기능 추가 상세 설명 필요시 작성하기
  
  - [x] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/ticketing/chs -> dev

### 변경 사항
- TicketService의 saveTicket 메서드를 ticketing으로 명명 변경
- Seat Entity에 checkSeatAvailability() 메서드를 추가하여 좌석의 예약 가능성을 확인하도록 로직을 이동
- SeatService의 checkSeatAvailability 메서드를 제거하고, Seat Entity로 메서드를 이동
- Ticket Entity의 builder 패턴 수정 및 deviceId parameter 추가
- TicketRequest에 대한 유효성 체크 로직을 TicketRequest 클래스 내부로 이동시켜 TicketController에 @Valid을 추가
  `@NotEmpty(message = "좌석 ID는 필수입니다.")`
  `@Size(min = 1, message = "최소 1개의 좌석 ID가 필요합니다.")`
- TicketService의 티켓팅 로직을 bookTicketForSeat()와 updateSeatAvailability() 메서드로 분리

### 검증 여부
- [x] postman으로 api 테스트 완료했습니다.
