### PR TITLE
`Member` 도메인 응답 형식 통일, Jackson 역직렬화 오류 해결 및 빈 스캔 문제 수정

### DIFF
--- a/src/main/java/com/kb/wallet/global/common/response/ApiResponse.java
+++ b/src/main/java/com/kb/wallet/global/common/response/ApiResponse.java
@@ -37,4 +37,7 @@ public class ApiResponse<T> {
     return new ApiResponse<>(data, 201, "Created");
   }
 
+  public static <T> ApiResponse<T> unauthorized(T data) {
+    return new ApiResponse<>(data, 404, "Unauthorized");
+  }
 }

--- a/src/main/java/com/kb/wallet/global/config/WebConfig.java
+++ b/src/main/java/com/kb/wallet/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.kb.wallet.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -10,9 +11,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebMvc
-//@ComponentScan(basePackages = "com.kb.wallet")
-//testcode 작성중 임시 제거 필요없을 거 같아서
+@ComponentScan(basePackages = "com.kb.wallet")
 public class WebConfig implements WebMvcConfigurer {
+
   @Value("${frontend.url}")
   private String frontendUrl;
 
@@ -21,7 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
     //Vue.js 빌드 결과물(정적 파일)을 제공할 경로를 설정합니다.
     //Vue.js 빌드 결과물이 /static 폴더에 배치되었다고 가정
     registry.addResourceHandler("/static/**")
-        .addResourceLocations("classpath:/static/");
+      .addResourceLocations("classpath:/static/");
   }
 
   @Override
@@ -32,10 +33,10 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedMethods("*")
-        .allowedOrigins(frontendUrl)
-        .allowedOriginPatterns("*")
-        .allowedHeaders("*")
-        .allowCredentials(true);
+      .allowedMethods("*")
+      .allowedOrigins(frontendUrl)
+      .allowedOriginPatterns("*")
+      .allowedHeaders("*")
+      .allowCredentials(true);
   }
 }

--- a/src/main/java/com/kb/wallet/member/controller/MemberController.java
+++ b/src/main/java/com/kb/wallet/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.kb.wallet.member.controller;
 
 import com.kb.wallet.global.common.response.ApiResponse;
-import com.kb.wallet.jwt.JwtFilter;
 import com.kb.wallet.jwt.TokenProvider;
 import com.kb.wallet.member.domain.Member;
 import com.kb.wallet.member.dto.request.LoginMemberRequest;
@@ -14,9 +13,6 @@ import javax.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -48,7 +44,7 @@ public class MemberController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<HashMap<String, Object>> loginMember(
+  public ApiResponse<HashMap<String, Object>> loginMember(
     @RequestBody @Valid LoginMemberRequest request) {
     HashMap<String, Object> map = new HashMap<>();
 
@@ -73,16 +69,12 @@ public class MemberController {
       map.put("result", "success");
       map.put("accessToken", accessToken);
 
-      // 헤더에 토큰 추가
-      HttpHeaders httpHeaders = new HttpHeaders();
-      httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + accessToken);
-
-      return new ResponseEntity<>(map, httpHeaders, HttpStatus.OK);
+      return ApiResponse.ok(map);
 
     } catch (AuthenticationException e) {
       map.put("result", "fail");
       map.put("message", "Login failed: " + e.getMessage());
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(map); // UNAUTHORIZED 반환
+      return ApiResponse.unauthorized(map);
     }
   }
 

--- a/src/main/java/com/kb/wallet/member/dto/request/LoginMemberRequest.java
+++ b/src/main/java/com/kb/wallet/member/dto/request/LoginMemberRequest.java
@@ -4,7 +4,9 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class LoginMemberRequest {

--- a/src/main/java/com/kb/wallet/member/dto/request/PinNumberVerificationRequest.java
+++ b/src/main/java/com/kb/wallet/member/dto/request/PinNumberVerificationRequest.java
@@ -4,7 +4,9 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class PinNumberVerificationRequest {

--- a/src/test/java/com/kb/wallet/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kb/wallet/member/controller/MemberControllerTest.java
@@ -15,7 +15,6 @@ import static org.springframework.test.util.AssertionErrors.assertEquals;
 import static org.springframework.test.util.AssertionErrors.assertTrue;
 
 import com.kb.wallet.global.common.response.ApiResponse;
-import com.kb.wallet.jwt.JwtFilter;
 import com.kb.wallet.jwt.TokenProvider;
 import com.kb.wallet.member.domain.Member;
 import com.kb.wallet.member.dto.request.LoginMemberRequest;
@@ -38,9 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -49,7 +45,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 @ExtendWith(MockitoExtension.class)
-public class MemberControllerTest {
+class MemberControllerTest {
 
   @Mock
   private MemberServiceImpl memberService;
@@ -221,17 +217,14 @@ public class MemberControllerTest {
     when(tokenProvider.createToken(anyString(), anyString())).thenReturn(accessToken);
 
     // when
-    ResponseEntity<HashMap<String, Object>> response = memberController.loginMember(request);
+    ApiResponse<HashMap<String, Object>> response = memberController.loginMember(request);
 
     // then
-    assertEquals("응답 상태는 200 OK 여야 합니다.", HttpStatus.OK, response.getStatusCode());
-    HashMap<String, Object> body = response.getBody();
+    assertEquals("응답 코드는 200 이어야 합니다.", 200, response.getResultCode());
+    HashMap<String, Object> body = response.getResult();
     assertEquals("결과는 success 여야 합니다.", "success", body.get("result"));
     assertEquals("AccessToken은 일치해야 합니다.", accessToken,
-      body.get("accessToken")); // Use the mocked token
-    HttpHeaders headers = response.getHeaders();
-    assertEquals("헤더에 JWT 토큰이 포함되어야 합니다.", "Bearer " + accessToken,
-      headers.getFirst(JwtFilter.AUTHORIZATION_HEADER));
+      body.get("accessToken"));
   }
 
   @Test
@@ -244,11 +237,11 @@ public class MemberControllerTest {
       });
 
     // when
-    ResponseEntity<HashMap<String, Object>> response = memberController.loginMember(request);
+    ApiResponse<HashMap<String, Object>> response = memberController.loginMember(request);
 
     // then
-    assertEquals("응답 상태는 UNAUTHORIZED 여야 합니다.", HttpStatus.UNAUTHORIZED, response.getStatusCode());
-    HashMap<String, Object> body = response.getBody();
+    assertEquals("응답 코드는 404 이어야 합니다.", 404, response.getResultCode());
+    HashMap<String, Object> body = response.getResult();
     assertEquals("결과는 fail 여야 합니다.", "fail", body.get("result"));
     assertTrue("메시지는 'Login failed: Login failed' 여야 합니다.",
       body.get("message").toString().startsWith("Login failed:"));


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* 기능 추가 상세 설명 필요시 작성하기
  
  - [ ] 기능 추가
  - [ ] 기능 삭제
  - [x] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
  - [x] 리팩터링

### 반영 브랜치
ex) refactor/member/lhh -> dev

### 변경 사항
**1. 로그인 API, 응답 형식 ApiResponse로 통일**
그에 맞게 테스트 코드도 수정

**2. DTO 기본 생성자 추가:**
LoginMemberRequest와 PinNumberVerificationRequest 클래스에 @NoArgsConstructor를 추가.
JSON 요청을 객체로 변환하는 과정에서 발생한 Jackson 역직렬화 오류(Cannot construct instance)를 해결.

**3. 빈 스캔 문제 수정:**
주석 처리되어 있던 @ComponentScan을 활성화하여 Spring이 자동으로 빈을 스캔하도록 처리.

### 검증 여부
- [x] postman으로 api 테스트 완료했습니다.
- [x] 모든 단위, 통합 테스트 검증 완료했습니다. 
